### PR TITLE
Fixed syntax according to Swift 2, added fade out option

### DIFF
--- a/Joystick.swift
+++ b/Joystick.swift
@@ -10,13 +10,14 @@ import Foundation
 import SpriteKit
 
 class Joystick : SKNode {
+    var shouldFadeOut: Bool = false
+    let kFadeAlphaLevel: CGFloat = 0.2
     let kThumbSpringBackDuration: Double =  0.3
     let backdropNode, thumbNode: SKSpriteNode
     var isTracking: Bool = false
     var velocity: CGPoint = CGPointMake(0, 0)
     var travelLimit: CGPoint = CGPointMake(0, 0)
     var angularVelocity: CGFloat = 0.0
-    var size: Float = 0.0
     
     func anchorPointInPoints() -> CGPoint {
         return CGPointMake(0, 0)
@@ -38,29 +39,30 @@ class Joystick : SKNode {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func touchesBegan(touches: NSSet, withEvent event: UIEvent) {
+    override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {
         for touch in touches {
-            var touchPoint: CGPoint = touch.locationInNode(self)
+            let touchPoint: CGPoint = touch.locationInNode(self)
             if self.isTracking == false && CGRectContainsPoint(self.thumbNode.frame, touchPoint) {
                 self.isTracking = true
+                self.alpha = 1.0
             }
         }
     }
     
-    override func touchesMoved(touches: NSSet, withEvent event: UIEvent) {
+    override func touchesMoved(touches: Set<UITouch>, withEvent event: UIEvent?) {
         for touch in touches {
-            var touchPoint: CGPoint = touch.locationInNode(self)
-
+            let touchPoint: CGPoint = touch.locationInNode(self)
+            
             if self.isTracking == true && sqrtf(powf((Float(touchPoint.x) - Float(self.thumbNode.position.x)), 2) + powf((Float(touchPoint.y) - Float(self.thumbNode.position.y)), 2)) < Float(self.thumbNode.size.width) {
                 if sqrtf(powf((Float(touchPoint.x) - Float(self.anchorPointInPoints().x)), 2) + powf((Float(touchPoint.y) - Float(self.anchorPointInPoints().y)), 2)) <= Float(self.thumbNode.size.width) {
-                    var moveDifference: CGPoint = CGPointMake(touchPoint.x - self.anchorPointInPoints().x, touchPoint.y - self.anchorPointInPoints().y)
+                    let moveDifference: CGPoint = CGPointMake(touchPoint.x - self.anchorPointInPoints().x, touchPoint.y - self.anchorPointInPoints().y)
                     self.thumbNode.position = CGPointMake(self.anchorPointInPoints().x + moveDifference.x, self.anchorPointInPoints().y + moveDifference.y)
                 } else {
-                    var vX: Double = Double(touchPoint.x) - Double(self.anchorPointInPoints().x)
-                    var vY: Double = Double(touchPoint.y) - Double(self.anchorPointInPoints().y)
-                    var magV: Double = sqrt(vX*vX + vY*vY)
-                    var aX: Double = Double(self.anchorPointInPoints().x) + vX / magV * Double(self.thumbNode.size.width)
-                    var aY: Double = Double(self.anchorPointInPoints().y) + vY / magV * Double(self.thumbNode.size.width)
+                    let vX: Double = Double(touchPoint.x) - Double(self.anchorPointInPoints().x)
+                    let vY: Double = Double(touchPoint.y) - Double(self.anchorPointInPoints().y)
+                    let magV: Double = sqrt(vX*vX + vY*vY)
+                    let aX: Double = Double(self.anchorPointInPoints().x) + vX / magV * Double(self.thumbNode.size.width)
+                    let aY: Double = Double(self.anchorPointInPoints().y) + vY / magV * Double(self.thumbNode.size.width)
                     self.thumbNode.position = CGPointMake(CGFloat(aX), CGFloat(aY))
                 }
             }
@@ -69,19 +71,27 @@ class Joystick : SKNode {
         }
     }
     
-    override func touchesEnded(touches: NSSet, withEvent event: UIEvent) {
+    override func touchesEnded(touches: Set<UITouch>, withEvent event: UIEvent?) {
         self.resetVelocity()
     }
     
-    override func touchesCancelled(touches: NSSet!, withEvent event: UIEvent!) {
+    override func touchesCancelled(touches: Set<UITouch>?, withEvent event: UIEvent?) {
         self.resetVelocity()
     }
     
     func resetVelocity() {
         self.isTracking = false
         self.velocity = CGPointZero
-        var easeOut: SKAction = SKAction.moveTo(self.anchorPointInPoints(), duration: kThumbSpringBackDuration)
+        let easeOut: SKAction = SKAction.moveTo(self.anchorPointInPoints(), duration: kThumbSpringBackDuration)
         easeOut.timingMode = SKActionTimingMode.EaseOut
         self.thumbNode.runAction(easeOut)
+        fadeOut()
+    }
+    
+    func fadeOut() {
+        if (shouldFadeOut) {
+            let action: SKAction = SKAction.fadeAlphaTo(kFadeAlphaLevel, duration: kThumbSpringBackDuration / 2)
+            self.runAction(action)
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ How to make the joystick
 4.Add the child to the scene
 
     joystick = Joystick()
-    joystick.position = CGPointMake(joystick.size.width * 2, joystick.size.height * 2)
+    joystick.zPosition = 3.0
+    joystick.position = CGPointMake(joystick.backdropNode.size.width / 2, joystick.backdropNode.size.height / 2)
+    joystick.shouldFadeOut = true
     self.addChild(joystick)
 
 Movement


### PR DESCRIPTION
Fade out setting allows joystick fade out while not touching, very useful in game mechanics. By default this option is false.
